### PR TITLE
Add shadowcss shadowdom polyfill to build

### DIFF
--- a/build.json
+++ b/build.json
@@ -1,6 +1,8 @@
 [
   "build/if-poly.js",
   "../ShadowDOM/build.json",
+  "src/patches-shadowdom-polyfill.js",
+  "src/ShadowCSS.js",
   "build/else.js",
   "../CustomElements/src/sidetable.js",
   "src/patches-shadowdom-native.js",


### PR DESCRIPTION
While testing on mobile safari and Firefox (23.0.1), errors would occur with the concat and minified builds of polymer.
I narrowed it down to `ShadowCSS.js` and `patches-shadowdom-polyfill.js` not being built.
